### PR TITLE
Add: font sizes 80, 96, 128, and 256

### DIFF
--- a/cosmic-viewer/src/app.rs
+++ b/cosmic-viewer/src/app.rs
@@ -60,10 +60,11 @@ use viewer_core::{
 };
 use viewer_toolbar::{ItemPriority, ToolbarItem, ToolbarMode, responsive_toolbar};
 use viewer_tools::{
-    ToolOperation,
+    FONT_SIZE_PRESETS_PT, ToolOperation,
     annotate::{
-        AnnotateColor, AnnotateTool, HighlighterPreview, PenPreview, PencilPreview, ShapeKind,
-        ShapePreview, TextDragHandle, TextOperation, TextPreview,
+        AnnotateColor, AnnotateTool, HighlighterPreview, PenPreview, ShapeKind, ShapePreview,
+        TextDragHandle, TextOperation, TextPreview,
+        tool::{FONT_SIZE_LABELS, pt_to_px},
     },
     crop::{CropOperation, CropRatio, CropSelection},
     rotate::{RotateDirection, RotateOperation},
@@ -1156,18 +1157,16 @@ impl CosmicViewer {
         let mut format_popover = popover(trigger);
 
         if self.show_text_format_menu {
-            let font_sizes = vec!["12pt", "16pt", "20pt", "24pt", "32pt", "48pt", "64pt"];
-            let font_size_values = [12.0_f32, 16.0, 20.0, 24.0, 32.0, 48.0, 64.0];
             // presets are exact integer-valued floats; match the active size to one.
-            let font_size_selected = font_size_values
+            let font_size_selected = FONT_SIZE_PRESETS_PT
                 .iter()
-                .position(|s| (*s - self.text_font_size).abs() < f32::EPSILON);
+                .position(|pt| (pt_to_px(*pt) - self.text_font_size).abs() < 0.01);
 
             let font_row = Row::new()
                 .push(dropdown(&self.font_families, self.text_font_index, |idx| {
                     ViewerMessage::Edit(EditMessage::TextFontFamily(idx))
                 }))
-                .push(dropdown(font_sizes, font_size_selected, |idx| {
+                .push(dropdown(&FONT_SIZE_LABELS, font_size_selected, |idx| {
                     ViewerMessage::Edit(EditMessage::TextFontSize(idx))
                 }))
                 .align_y(Alignment::Center)
@@ -1393,7 +1392,7 @@ impl Application for CosmicViewer {
             selected_shape: AnnotateTool::Rectangle,
             text_font_family: default_family,
             text_font_index: font_index,
-            text_font_size: 24.0,
+            text_font_size: pt_to_px(24.0),
             text_bold: false,
             text_italic: false,
             text_underline: false,
@@ -3096,18 +3095,10 @@ impl Application for CosmicViewer {
                                         preview.as_any_mut().downcast_mut::<PenPreview>()
                                     {
                                         pen.width = size;
-                                    } else if let Some(pencil) =
-                                        preview.as_any_mut().downcast_mut::<PencilPreview>()
-                                    {
-                                        pencil.width = size;
                                     } else if let Some(shape) =
                                         preview.as_any_mut().downcast_mut::<ShapePreview>()
                                     {
                                         shape.width = size;
-                                    } else if let Some(text) =
-                                        preview.as_any_mut().downcast_mut::<TextPreview>()
-                                    {
-                                        text.font_size = size * 8.0;
                                     }
                                 }
                             }
@@ -3178,10 +3169,6 @@ impl Application for CosmicViewer {
                         if let Some(preview) = self.viewport.preview_mut() {
                             if let Some(pen) = preview.as_any_mut().downcast_mut::<PenPreview>() {
                                 pen.color = color.0;
-                            } else if let Some(pencil) =
-                                preview.as_any_mut().downcast_mut::<PencilPreview>()
-                            {
-                                pencil.color = color.0;
                             } else if let Some(highlighter) =
                                 preview.as_any_mut().downcast_mut::<HighlighterPreview>()
                             {
@@ -3454,10 +3441,6 @@ impl Application for CosmicViewer {
                                 preview.as_any_mut().downcast_mut::<PenPreview>()
                             {
                                 pen.color = self.annotate_color.0;
-                            } else if let Some(pencil) =
-                                preview.as_any_mut().downcast_mut::<PencilPreview>()
-                            {
-                                pencil.color = self.annotate_color.0;
                             } else if let Some(highlighter) =
                                 preview.as_any_mut().downcast_mut::<HighlighterPreview>()
                             {
@@ -3540,14 +3523,14 @@ impl Application for CosmicViewer {
                         self.sync_text_format_models();
                     }
                     EditMessage::TextFontSize(idx) => {
-                        let sizes = [12.0_f32, 16.0, 20.0, 24.0, 32.0, 48.0, 64.0];
-                        if let Some(&size) = sizes.get(idx) {
-                            self.text_font_size = size;
+                        if let Some(&size_pt) = FONT_SIZE_PRESETS_PT.get(idx) {
+                            let size_px = pt_to_px(size_pt);
+                            self.text_font_size = size_px;
                             if let Some(preview) = self.viewport.preview_mut()
                                 && let Some(text) =
                                     preview.as_any_mut().downcast_mut::<TextPreview>()
                             {
-                                text.update_font_size(size);
+                                text.update_font_size(size_px);
                             }
                             self.viewport.rebuild_display();
                         }

--- a/viewer-tools/src/annotate.rs
+++ b/viewer-tools/src/annotate.rs
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod color;
-mod tool;
+pub mod tool;
 
 pub use color::AnnotateColor;
 pub use tool::{
-    AnnotateTool, FONT_SIZE_PRESETS,
+    AnnotateTool, FONT_SIZE_LABELS, FONT_SIZE_PRESETS_PT,
     highlighter::{HighlighterOperation, HighlighterPreview},
     pen::{PenOperation, PenPreview},
     pencil::{PencilOperation, PencilPreview},
+    pt_to_px,
     shapes::{ShapeKind, ShapeOperation, ShapePreview},
     text::{TextDragHandle, TextOperation, TextPreview},
 };

--- a/viewer-tools/src/annotate/tool.rs
+++ b/viewer-tools/src/annotate/tool.rs
@@ -6,7 +6,7 @@ pub mod pencil;
 pub mod shapes;
 pub mod text;
 
-pub use text::FONT_SIZE_PRESETS;
+pub use text::{FONT_SIZE_LABELS, FONT_SIZE_PRESETS_PT, pt_to_px};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AnnotateTool {

--- a/viewer-tools/src/annotate/tool/shapes.rs
+++ b/viewer-tools/src/annotate/tool/shapes.rs
@@ -96,6 +96,7 @@ fn build_path(kind: ShapeKind, start: Point, end: Point) -> Path {
     }
 }
 
+#[must_use]
 pub fn normalize_rect(a: Point, b: Point) -> Rectangle {
     Rectangle::new(
         Point::new(a.x.min(b.x), a.y.min(b.y)),
@@ -167,6 +168,7 @@ fn arrow_head_points(start: Point, end: Point, width: f32) -> Option<(Point, Poi
 }
 
 #[allow(clippy::cast_precision_loss)] // reason: point index/count are small (<=10), exact in f32
+#[must_use]
 pub fn star_vertices(start: Point, end: Point) -> Vec<Point> {
     let bounds = normalize_rect(start, end);
     let center_x = bounds.x + bounds.width / 2.0;
@@ -198,6 +200,7 @@ pub fn star_vertices(start: Point, end: Point) -> Vec<Point> {
 }
 
 #[allow(clippy::cast_precision_loss)] // reason: side index/count are small (typically <=12), exact in f32
+#[must_use]
 pub fn polygon_vertices(start: Point, end: Point, sides: usize) -> Vec<Point> {
     let bounds = normalize_rect(start, end);
     let center_x = bounds.x + bounds.width / 2.0;
@@ -233,6 +236,7 @@ fn closed_path(vertices: &[Point]) -> Path {
 /// Build line segments for an arrow (shaft + head), sized for a `width`-thick stroke. Used by
 /// `apply()`; `[1]` and `[2]` carry the head's left/right corners with the tip as their second
 /// point (see `shapes/operation.rs`).
+#[must_use]
 pub fn arrow_segments(start: Point, end: Point, width: f32) -> Vec<(Point, Point)> {
     let Some((base, left, right)) = arrow_head_points(start, end, width) else {
         return vec![(start, end)];

--- a/viewer-tools/src/annotate/tool/text.rs
+++ b/viewer-tools/src/annotate/tool/text.rs
@@ -106,6 +106,7 @@ pub fn color_channel_u8(component: f32) -> u8 {
     (component * 255.0).round().clamp(0.0, 255.0) as u8
 }
 
+#[must_use]
 pub const fn encode_align(align: cosmic_text::Align) -> u8 {
     match align {
         cosmic_text::Align::Center => 1,
@@ -115,6 +116,7 @@ pub const fn encode_align(align: cosmic_text::Align) -> u8 {
     }
 }
 
+#[must_use]
 pub const fn decode_align(val: u8) -> cosmic_text::Align {
     match val {
         1 => cosmic_text::Align::Center,
@@ -126,8 +128,24 @@ pub const MIN_BOX_WIDTH: f32 = 40.0;
 pub const MIN_BOX_HEIGHT: f32 = 20.0;
 pub const DEFAULT_BOX_WIDTH: f32 = 200.0;
 pub const LINE_HEIGHT_FACTOR: f32 = 1.2;
-pub const FONT_SIZE_PRESETS: [f32; 7] = [12.0, 16.0, 20.0, 24.0, 32.0, 40.0, 64.0];
+pub const PT_TO_PX: f32 = 96.0 / 72.0;
+pub const FONT_SIZE_PRESETS_PT: [f32; 11] = [
+    12.0, 16.0, 20.0, 24.0, 32.0, 48.0, 64.0, 80.0, 96.0, 128.0, 256.0,
+];
+pub const FONT_SIZE_LABELS: [&str; 11] = [
+    "12pt", "16pt", "20pt", "24pt", "32pt", "48pt", "64pt", "80pt", "96pt", "128pt", "256pt",
+];
 const DRAG_THRESHOLD: f32 = 5.0;
+
+#[must_use]
+pub fn pt_to_px(pt: f32) -> f32 {
+    pt * PT_TO_PX
+}
+
+#[must_use]
+pub fn px_to_pt(px: f32) -> f32 {
+    px / PT_TO_PX
+}
 
 #[derive(Debug, Clone)]
 pub struct TextSpan {
@@ -143,6 +161,7 @@ pub struct TextSpan {
 
 pub type SpanLine<'a> = (String, Vec<&'a TextSpan>, Option<u8>);
 
+#[must_use]
 pub fn group_spans<'a>(spans: &'a [TextSpan]) -> Vec<SpanLine<'a>> {
     let mut lines: Vec<SpanLine<'a>> = vec![(String::new(), Vec::new(), None)];
     for span in spans {
@@ -161,6 +180,7 @@ pub fn group_spans<'a>(spans: &'a [TextSpan]) -> Vec<SpanLine<'a>> {
     lines
 }
 
+#[must_use]
 pub fn span_attrs<'a>(base: cosmic_text::Attrs<'a>, span: &TextSpan) -> cosmic_text::Attrs<'a> {
     let mut a = base
         .weight(if span.bold {
@@ -191,6 +211,7 @@ pub fn span_attrs<'a>(base: cosmic_text::Attrs<'a>, span: &TextSpan) -> cosmic_t
     a
 }
 
+#[must_use]
 pub fn build_buffer_line(
     text: &str,
     attrs_list: cosmic_text::AttrsList,
@@ -208,15 +229,20 @@ pub fn build_buffer_line(
     line
 }
 
+#[must_use]
 pub fn content_height(buf: &cosmic_text::Buffer) -> f32 {
     buf.layout_runs()
         .fold(0.0, |h, run| (run.line_top + run.line_height).max(h))
 }
 
-pub fn snap_font_size(target: f32) -> f32 {
-    FONT_SIZE_PRESETS
+#[must_use]
+pub fn snap_font_size(target_px: f32) -> f32 {
+    let target_pt = px_to_pt(target_px);
+    let snapped_pt = FONT_SIZE_PRESETS_PT
         .iter()
         .copied()
-        .min_by(|a, b| (a - target).abs().total_cmp(&(b - target).abs()))
-        .unwrap_or(24.0)
+        .min_by(|a, b| (a - target_pt).abs().total_cmp(&(b - target_pt).abs()))
+        .unwrap_or(24.0);
+
+    pt_to_px(snapped_pt)
 }

--- a/viewer-tools/src/lib.rs
+++ b/viewer-tools/src/lib.rs
@@ -6,7 +6,7 @@ pub mod renderer;
 pub mod rotate;
 
 // Re-exports
-pub use crate::annotate::FONT_SIZE_PRESETS;
+pub use crate::annotate::FONT_SIZE_PRESETS_PT;
 
 use crate::rotate::RotateDirection;
 use cosmic::{


### PR DESCRIPTION
Added the requested font sizes and some intermediate sizes as well so there's not as big of a jump between 64 and 128 for release issue #17.

Also removed the stray pencil references in app.rs as they were missed during the clean up phase before transferring.