### PR TITLE
Fix zoom to fit

### DIFF
--- a/cosmic-viewer/src/app.rs
+++ b/cosmic-viewer/src/app.rs
@@ -2922,9 +2922,7 @@ impl Application for CosmicViewer {
                     self.viewport.zoom_to_actual_size(viewport_size);
                 }
                 CanvasMessage::FillView => {
-                    let bounds = self.viewport.last_bounds().get();
-                    let viewport_size = Size::new(bounds.width, bounds.height);
-                    self.viewport.fill_zoom(viewport_size);
+                    self.viewport.set_zoom(self.viewport.fit_zoom(None));
                 }
                 CanvasMessage::Fullscreen => {
                     self.is_fullscreen = !self.is_fullscreen;

--- a/cosmic-viewer/src/app.rs
+++ b/cosmic-viewer/src/app.rs
@@ -2194,7 +2194,8 @@ impl Application for CosmicViewer {
                     if let Some(idx) = next_idx {
                         tasks.push(self.update(ViewerMessage::Nav(NavMessage::GridActivate(idx))));
                     } else {
-                        self.viewport.set_image(None, None);
+                        self.viewport
+                            .set_image(None, None, self.config.fit_to_window);
                     }
 
                     // Trash the file
@@ -2624,11 +2625,15 @@ impl Application for CosmicViewer {
                     }
                     self.was_narrow = narrow;
                 }
+                if self.config.fit_to_window {
+                    self.viewport.set_zoom(self.viewport.fit_zoom(None));
+                }
             }
             ViewerMessage::Nav(msg) => match msg {
                 NavMessage::ScanComplete(dir, images, select) => {
                     self.viewport.cancel_tool();
-                    self.viewport.set_image(None, None);
+                    self.viewport
+                        .set_image(None, None, self.config.fit_to_window);
 
                     self.nav.set_images(dir, images, select.as_deref());
 
@@ -2733,6 +2738,7 @@ impl Application for CosmicViewer {
                                     height: cached.height,
                                 }),
                                 Some(cached.image),
+                                self.config.fit_to_window,
                             );
                         }
                         // Don't clear the viewport - keep the previous image
@@ -2829,6 +2835,7 @@ impl Application for CosmicViewer {
                                         height: cached.height,
                                     }),
                                     Some(cached.image),
+                                    self.config.fit_to_window,
                                 );
                             }
                         }
@@ -2913,6 +2920,11 @@ impl Application for CosmicViewer {
                     let bounds = self.viewport.last_bounds().get();
                     let viewport_size = Size::new(bounds.width, bounds.height);
                     self.viewport.zoom_to_actual_size(viewport_size);
+                }
+                CanvasMessage::FillView => {
+                    let bounds = self.viewport.last_bounds().get();
+                    let viewport_size = Size::new(bounds.width, bounds.height);
+                    self.viewport.fill_zoom(viewport_size);
                 }
                 CanvasMessage::Fullscreen => {
                     self.is_fullscreen = !self.is_fullscreen;
@@ -3235,6 +3247,7 @@ impl Application for CosmicViewer {
                                     height: cached.height,
                                 }),
                                 Some(cached.image),
+                                self.config.fit_to_window,
                             );
                         }
                     }
@@ -3874,9 +3887,9 @@ impl Application for CosmicViewer {
 
         Subscription::batch([
             event::listen_with(|event, _status, _id| match event {
-                iced::Event::Window(iced::window::Event::Resized(size)) => {
-                    Some(ViewerMessage::WindowResized(size))
-                }
+                iced::Event::Window(
+                    iced::window::Event::Resized(size) | iced::window::Event::Opened { size, .. },
+                ) => Some(ViewerMessage::WindowResized(size)),
                 iced::Event::Window(iced::window::Event::CloseRequested) => {
                     Some(ViewerMessage::CloseRequested)
                 }

--- a/cosmic-viewer/src/key_binds.rs
+++ b/cosmic-viewer/src/key_binds.rs
@@ -38,6 +38,7 @@ pub enum MenuAction {
     ZoomOut,
     ActualSize,
     FitToView,
+    FillView,
     Fullscreen,
     SetWallpaper,
     MoveToTrash,
@@ -68,6 +69,7 @@ impl MenuAction {
             Self::ZoomOut => ViewerMessage::Canvas(CanvasMessage::ZoomOut),
             Self::ActualSize => ViewerMessage::Canvas(CanvasMessage::ActualSize),
             Self::FitToView => ViewerMessage::Canvas(CanvasMessage::FitToView),
+            Self::FillView => ViewerMessage::Canvas(CanvasMessage::FillView),
             Self::Fullscreen => ViewerMessage::Canvas(CanvasMessage::Fullscreen),
             // Edit Messages
             Self::RotateLeft => ViewerMessage::Edit(EditMessage::RotateLeft),
@@ -175,6 +177,14 @@ pub fn init_keybinds() -> HashMap<KeyBind, MenuAction> {
             key: Key::Character("1".into()),
         },
         MenuAction::ActualSize,
+    );
+
+    binds.insert(
+        KeyBind {
+            modifiers: vec![Modifier::Ctrl],
+            key: Key::Character("2".into()),
+        },
+        MenuAction::FillView,
     );
 
     binds.insert(

--- a/viewer-canvas/src/program/manager.rs
+++ b/viewer-canvas/src/program/manager.rs
@@ -96,7 +96,12 @@ impl ViewportManager {
         &mut self.operations
     }
 
-    pub fn set_image(&mut self, image: Option<CanvasImage>, base: Option<DynamicImage>) {
+    pub fn set_image(
+        &mut self,
+        image: Option<CanvasImage>,
+        base: Option<DynamicImage>,
+        fit_to_window: bool,
+    ) {
         let image = match (image, base.as_ref()) {
             (Some(mut img), Some(base)) => {
                 img.width = base.width();
@@ -105,9 +110,13 @@ impl ViewportManager {
             }
             (img, _) => img,
         };
+        self.zoom = if fit_to_window {
+            self.fit_zoom(image.as_ref())
+        } else {
+            1.0
+        };
         self.image = image;
         self.working_image = base;
-        self.zoom = 1.0;
         self.pan = Vector::ZERO;
         self.active_preview = None;
         self.active_tool = None;
@@ -180,6 +189,19 @@ impl ViewportManager {
             let zy = frame_size.height / (image.height as f32 * fit_scale);
             zx.max(zy).max(1.0)
         })
+    }
+
+    pub fn fit_zoom(&self, image: Option<&CanvasImage>) -> f32 {
+        let Rectangle { width, height, .. } = self.last_bounds().get();
+        if width > 0.0
+            && height > 0.0
+            && let Some(image) = image.or_else(|| self.image())
+        {
+            #[allow(clippy::cast_precision_loss)]
+            super::fit_scale_uncapped(width, height, image.width as f32, image.height as f32)
+        } else {
+            1.0
+        }
     }
 
     pub const fn set_zoom(&mut self, zoom: f32) {

--- a/viewer-canvas/src/state.rs
+++ b/viewer-canvas/src/state.rs
@@ -37,6 +37,7 @@ pub enum CanvasMessage {
     ZoomBy(f32),
     Pan(Vector),
     ActualSize,
+    FillView,
     FitToView,
     Fullscreen,
     ToolStart(Point),


### PR DESCRIPTION
`fit_to_window` is enabled by default but it was unused throughout the code. I fixed zoom to fit by ensuring ViewportManager::set_image checks and uses the config value.

Iced (and thus COSMIC) may receive an incorrect window size on start which in turn breaks zoom to fit. I mitigated against that by emitting a window resized event for both window creation and resize, and then manually rejiggering the zoom if zoom to fit is enabled.

I tested on COSMIC, Xfce, and Sway. Sway is where I encountered the resize issue because it seems windows are created very small then resized immediately - so, the initial small window broke zoom to fit.

---

I implemented this same feature for Oculante a few months ago: woelper/oculante#741 :grin: 

I think it makes sense for the config to eventually store an enum for the type of zoom instead of a bool for fit_to_window only. I reused what was already there rather than expanding the scope of this patch.